### PR TITLE
♻️ Refactor : 카드셋을 17종으로 확장 및 enum 기반 구조 적용

### DIFF
--- a/SaboteurKit/Sources/SaboteurKit/Models/Card.swift
+++ b/SaboteurKit/Sources/SaboteurKit/Models/Card.swift
@@ -27,24 +27,24 @@ public struct Card: Sendable {
 
 public let cardSet: [Card] = [
     // 연결 가능한 길 카드
-    Card(directions: [true, true, true, false], connect: true, symbol: "┴"),      // t
-    Card(directions: [true, true, false, true], connect: true, symbol: "│"),      // tb
-    Card(directions: [true, false, true, true], connect: true, symbol: "└"),      // tr
-    Card(directions: [true, true, true, false], connect: true, symbol: "┘"),      // tl
-    Card(directions: [false, true, false, true], connect: true, symbol: "─"),     // rl
-    Card(directions: [true, false, true, true], connect: true, symbol: "├"),      // trb
-    Card(directions: [true, true, true, false], connect: true, symbol: "┤"),      // trl
-    Card(directions: [true, true, true, true], connect: true, symbol: "┼"),       // trbl
+    Card(directions: [true, false, false, true], connect: true, symbol: "┘"), // tl
+    Card(directions: [true, true, false, false], connect: true, symbol: "└"), // tr
+    Card(directions: [true, false, true, true], connect: true, symbol: "│"), // tb
+    Card(directions: [false, true, false, true], connect: true, symbol: "─"), // rl
+    Card(directions: [true, true, true, false], connect: true, symbol: "├"), // trb
+    Card(directions: [true, true, false, true], connect: true, symbol: "ㅗ"), // trl
+    Card(directions: [true, true, true, true], connect: true, symbol: "┼"), // trbl
 
     // 방해 카드
-    Card(directions: [false, false, false, false], connect: false, symbol: "⨯"),  // lBlock
-    Card(directions: [true, true, false, true], connect: false, symbol: "╵"),     // tbBlock
-    Card(directions: [true, false, true, false], connect: false, symbol: "╰"),    // trBlock
-    Card(directions: [true, true, false, false], connect: false, symbol: "╯"),    // tlBlock
-    Card(directions: [false, true, false, true], connect: false, symbol: "╴"),    // rlBlock
-    Card(directions: [true, false, true, true], connect: false, symbol: "┡"),     // trbBlock
-    Card(directions: [true, true, true, false], connect: false, symbol: "┩"),     // trlBlock
-    Card(directions: [true, true, true, true], connect: false, symbol: "╳"),      // trblBlock
+    Card(directions: [true, false, false, false], connect: false, symbol: "▴"), // tBlock
+    Card(directions: [false, false, false, true], connect: false, symbol: "◀︎"), // lBlock
+    Card(directions: [true, false, false, true], connect: false, symbol: "▴◀︎"), // tlBlock
+    Card(directions: [true, true, false, false], connect: false, symbol: "╰"), // trBlock
+    Card(directions: [true, false, true, true], connect: false, symbol: "▴▾"), // tbBlock
+    Card(directions: [false, true, false, true], connect: false, symbol: "◀︎‣"), // rlBlock
+    Card(directions: [true, true, true, false], connect: false, symbol: "▴‣▾"), // trbBlock
+    Card(directions: [true, true, false, true], connect: false, symbol: "▴‣◀︎"), // trlBlock
+    Card(directions: [true, true, true, true], connect: false, symbol: "╳"), // trblBlock
 
     // 폭탄 카드
     Card(directions: [false, false, false, false], connect: false, symbol: "💣"), // bomb

--- a/SaboteurKit/Sources/SaboteurKit/Models/Card.swift
+++ b/SaboteurKit/Sources/SaboteurKit/Models/Card.swift
@@ -2,7 +2,14 @@
 
 import Foundation
 
+public enum PathCardType: CaseIterable, Sendable {
+    case t, tb, tr, tl, rl, trb, trl, trbl
+    case lBlock, tbBlock, trBlock, tlBlock, rlBlock, trbBlock, trlBlock, trblBlock
+    case bomb
+}
+
 public struct Card: Sendable {
+//    public let type: PathCardType
     public let directions: [Bool]
     public let connect: Bool
     public let symbol: String
@@ -19,11 +26,26 @@ public struct Card: Sendable {
 }
 
 public let cardSet: [Card] = [
-    Card(directions: [true, false, true, false], connect: true, symbol: "│"), // 상하
-    Card(directions: [false, true, false, true], connect: true, symbol: "─"), // 좌우
-    Card(directions: [true, true, false, false], connect: true, symbol: "└"), // 상우
-    Card(directions: [false, true, true, false], connect: true, symbol: "┌"), // 하우
-    Card(directions: [true, true, true, true], connect: true, symbol: "┼"), // 전방향
-    Card(directions: [false, false, false, false], connect: false, symbol: "💣"), // 폭탄
-    Card(directions: [true, true, true, true], connect: false, symbol: "⦻"), // 전방, 방해
+    // 연결 가능한 길 카드
+    Card(directions: [true, true, true, false], connect: true, symbol: "┴"),      // t
+    Card(directions: [true, true, false, true], connect: true, symbol: "│"),      // tb
+    Card(directions: [true, false, true, true], connect: true, symbol: "└"),      // tr
+    Card(directions: [true, true, true, false], connect: true, symbol: "┘"),      // tl
+    Card(directions: [false, true, false, true], connect: true, symbol: "─"),     // rl
+    Card(directions: [true, false, true, true], connect: true, symbol: "├"),      // trb
+    Card(directions: [true, true, true, false], connect: true, symbol: "┤"),      // trl
+    Card(directions: [true, true, true, true], connect: true, symbol: "┼"),       // trbl
+
+    // 방해 카드
+    Card(directions: [false, false, false, false], connect: false, symbol: "⨯"),  // lBlock
+    Card(directions: [true, true, false, true], connect: false, symbol: "╵"),     // tbBlock
+    Card(directions: [true, false, true, false], connect: false, symbol: "╰"),    // trBlock
+    Card(directions: [true, true, false, false], connect: false, symbol: "╯"),    // tlBlock
+    Card(directions: [false, true, false, true], connect: false, symbol: "╴"),    // rlBlock
+    Card(directions: [true, false, true, true], connect: false, symbol: "┡"),     // trbBlock
+    Card(directions: [true, true, true, false], connect: false, symbol: "┩"),     // trlBlock
+    Card(directions: [true, true, true, true], connect: false, symbol: "╳"),      // trblBlock
+
+    // 폭탄 카드
+    Card(directions: [false, false, false, false], connect: false, symbol: "💣"), // bomb
 ]


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- #216

### 🧶 주요 변경 내용 (Summary)
기존 7종의 제한된 cardSet을 전면 리팩토링하여, 전체 17종 카드에 대한 enum 기반의 카드 정의를 적용했습니다.  
향후 다양한 카드 타입에 따른 로직 분기, UI 연결 등을 위한 구조 기반을 마련한 작업입니다.

- `PathCardType` enum 정의 (총 17종)
- 각 카드 타입의 `directions`, `connect`, `symbol` 정보를 기반으로 한 `cardSet` 재구성
- 기존 문자열 하드코딩 방식 제거 및 의미 기반 설계 적용

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<img width="300" alt="CLI" src="https://github.com/user-attachments/assets/f9ec1ea4-5953-416a-a9e8-5a7357ef3868" >

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] CLI 및 APP 정상 빌드
- [x] CLI 동작시 기존 7개 카드의 경우 `Board.isPlacable()` 가능
- [ ] 새로 추가된 카드의 경우 `Board.isPlacable()`...


### 💬 기타 공유 사항

- 기존에는 단 7장의 카드만 정의되어 있어 테스트 케이스 확장 및 실제 룰 구현에 제약이 있었습니다.
- 전체 카드 타입을 명시적으로 정의함으로써 카드별 특징(연결 방향, 방해 여부 등)을 보다 명확하게 표현하고 확장 가능성을 확보합니다.

### 🙇🏻‍♀️ 리뷰 가이드 (선택)

- `Board.isPlacable()` 로직에서 버그가 있는 것으로 추측...됩니다!
  - 현재 구조에서는 **기존 7종 카드만 연결이 허용**되고, 새로 추가된 카드 타입들은 대부분 배치가 거부됩니다.
  - 이는 `isPlacable()` 내부 로직을 분석한 후에 수정을 진행해야한다고 판단했습니다.
  - 본 PR에서는 해당 로직에는 손대지 않았습니다.