### PR TITLE
✨ Feature: #219 Color-chip-setting-at-assets

### DIFF
--- a/Saboteur/Assets.xcassets/Color/Grayscale/Black.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Grayscale/Black.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Grayscale/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Grayscale/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Grayscale/Gray2.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Grayscale/Gray2.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE2",
+          "green" : "0xE9",
+          "red" : "0xEF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Grayscale/White-bg.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Grayscale/White-bg.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFA",
+          "red" : "0xF5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Grayscale/White.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Grayscale/White.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Grayscale/gray.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Grayscale/gray.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB7",
+          "green" : "0xB7",
+          "red" : "0xB7"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Emerald/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Emerald/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Emerald/Emerald1.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Emerald/Emerald1.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x91",
+          "green" : "0x86",
+          "red" : "0x3D"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Emerald/Emerald2.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Emerald/Emerald2.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5A",
+          "green" : "0x50",
+          "red" : "0x19"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Emerald/Emerald3.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Emerald/Emerald3.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA1",
+          "green" : "0x99",
+          "red" : "0x67"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Emerald/EmeraldYellow.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Emerald/EmeraldYellow.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAA",
+          "green" : "0xA3",
+          "red" : "0x58"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Ivory/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Ivory/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Ivory/Ivory1.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Ivory/Ivory1.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE5",
+          "green" : "0xF9",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Ivory/Ivory2.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Ivory/Ivory2.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC8",
+          "green" : "0xE1",
+          "red" : "0xEB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Ivory/Ivory3.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Ivory/Ivory3.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC3",
+          "green" : "0xD2",
+          "red" : "0xE1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Ivory/Ivory4.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Ivory/Ivory4.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAF",
+          "green" : "0xC7",
+          "red" : "0xD1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Secondary/Blue1.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Secondary/Blue1.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE7",
+          "green" : "0xA7",
+          "red" : "0x07"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Secondary/Blue2.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Secondary/Blue2.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF0",
+          "green" : "0xEB",
+          "red" : "0xC3"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Secondary/Blue3.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Secondary/Blue3.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF5",
+          "green" : "0xF6",
+          "red" : "0xD3"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Secondary/Blue4.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Secondary/Blue4.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD7",
+          "green" : "0xCD",
+          "red" : "0x73"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Secondary/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Secondary/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Secondary/Yellow1.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Secondary/Yellow1.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x32",
+          "green" : "0xC8",
+          "red" : "0xF0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/Secondary/Yellow2.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/Secondary/Yellow2.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xAA",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/etc/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/etc/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/etc/Green.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/etc/Green.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x58",
+          "green" : "0x6C",
+          "red" : "0x3C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/etc/Mint.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/etc/Mint.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEA",
+          "green" : "0xFC",
+          "red" : "0xD2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/etc/Orange.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/etc/Orange.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB2",
+          "green" : "0xDF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/etc/Pink.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/etc/Pink.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7D",
+          "green" : "0x8C",
+          "red" : "0xFA"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Saboteur/Assets.xcassets/Color/etc/Red.colorset/Contents.json
+++ b/Saboteur/Assets.xcassets/Color/etc/Red.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDA",
+          "green" : "0xE9",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #219 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- Assets에 Color 추가함
- 폴더 구조로 Color을 만들고 그 아래 namespace을 이용해서 분리구조만듬

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<img width="1288" height="723" alt="스크린샷 2025-07-22 오전 6 57 11" src="https://github.com/user-attachments/assets/2060ea46-a740-466a-9bd5-9db1bde7d914" />
<img width="1414" height="721" alt="스크린샷 2025-07-22 오전 7 02 49" src="https://github.com/user-attachments/assets/5e885c81-f835-41d9-b919-639b334cb38f" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->
     Text("Color, Emerald!")
            .padding()
            .font(.largeTitle)
            .fontWeight(.bold)
            .foregroundStyle(Color.Emerald.emerald1)
        Text("Color, Gray!")
            .padding()
            .font(.largeTitle)
            .fontWeight(.bold)
            .foregroundStyle(Color.Grayscale.gray)
        Text("Color, ETC!")
            .padding()
            .font(.largeTitle)
            .fontWeight(.bold)
            .foregroundStyle(Color.Etc.pink)
        Text("Color, Secondary!")
            .padding()
            .font(.largeTitle)
            .fontWeight(.bold)
            .foregroundStyle(Color.Secondary.blue4)

위와 같이 Color.Etc.pink 사용하면 됩니다. 

- [ ] 정상적으로 반영되는 것을 확인함.

---
