### PR TITLE
✨ Feat: #223 앱 최초 접속 시 닉네임 설정 모달 열림

### DIFF
--- a/P2PKit/Sources/P2PKit/Public/Peer.swift
+++ b/P2PKit/Sources/P2PKit/Public/Peer.swift
@@ -45,8 +45,8 @@ extension Peer {
         {
             return Peer(peerID, id: id)
         } else {
-            let randomAnimal = Array("🦊🐯🐹🐶🐸🐵🐮🦄").randomElement()!
-            let peerID = MCPeerID(displayName: "\(randomAnimal) \(UIDevice.current.name)")
+            let initialName = "TEMP_USER_\(UUID().uuidString.prefix(4))"
+            let peerID = MCPeerID(displayName: "\(initialName)")
             return resetMyPeer(with: peerID)
         }
     }

--- a/Saboteur.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Saboteur.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "2cc206d745401a1142e3f0a80083743f5493062e641cda64c3f825995589b887",
   "pins" : [
     {
       "identity" : "swift-log",
@@ -11,5 +10,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Saboteur/Extensions/DropShadow+extension.swift
+++ b/Saboteur/Extensions/DropShadow+extension.swift
@@ -21,11 +21,15 @@ extension View {
 
 // fill()은 Shape 전용 메서드
 extension Shape {
+    func colorinnerShadow(color: Color = Color.black.opacity(0.1)) -> some View {
+        fill(.shadow(.inner(color: color, radius: 0, x: 0, y: -4)))
+    }
+
     func innerShadow(
         color: Color = .black.opacity(0.1),
         radius: CGFloat = 1,
         x: CGFloat = 0,
-        y: CGFloat = -1
+        y: CGFloat = -4
     ) -> some View {
         fill(.shadow(.inner(color: color, radius: radius, x: x, y: y)))
     }
@@ -33,8 +37,6 @@ extension Shape {
 
 // 사용 예시
 struct DropShadowExample: View {
-    @State private var isSelected: Bool = false
-
     var body: some View {
         ZStack {
             Color.gray
@@ -59,19 +61,8 @@ struct DropShadowExample: View {
                     .foregroundStyle(.red)
 
                 Text("inner shadow")
-                Button {
-                    isSelected = true
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                        isSelected = false
-                    }
-                } label: {
-                    RoundedRectangle(cornerRadius: 20)
-                        .fill(.shadow(.inner(color: Color.black.opacity(0.1), radius: 1, x: 0, y: isSelected ? -2 : 0)))
-                        .frame(width: 100, height: 100)
-                        .foregroundStyle(.red)
-                        .offset(y: isSelected ? 2 : 0)
-                        .animation(.easeOut(duration: 0.005), value: isSelected)
-                }
+                RoundedRectangle(cornerRadius: 10)
+                    .frame(width: 100, height: 100)
             }
         }
     }

--- a/Saboteur/Features/Component/FooterButton.swift
+++ b/Saboteur/Features/Component/FooterButton.swift
@@ -28,7 +28,7 @@ struct FooterButton: View {
                     .fill(.shadow(.inner(color: Color.black.opacity(0.1), radius: 0, x: 0, y: isSelected ? 0 : -4)))
                     .frame(maxWidth: .infinity)
                     .frame(height: 55)
-                    .foregroundStyle(isDisabled == true ? Color.gray : Color.Emerald.emerald2)
+                    .foregroundStyle(isDisabled == true ? Color.Grayscale.gray : Color.Emerald.emerald2)
 
                 Text(title)
                     .foregroundStyle(Color.Grayscale.whiteBg)

--- a/Saboteur/Features/GamePlay/GameResultView.swift
+++ b/Saboteur/Features/GamePlay/GameResultView.swift
@@ -48,7 +48,7 @@ struct GameResultView: View {
                         if let winnerCard = players.first(where: { $0 == name }) {
                             ZStack {
                                 RoundedRectangle(cornerRadius: 10)
-                                    .innerShadow()
+                                    .colorinnerShadow(color: Color.Ivory.ivory3)
                                     .frame(width: winnerCardWidth, height: winnerCardHeight)
                                     .foregroundStyle(Color.Ivory.ivory1)
 

--- a/Saboteur/Features/Lobby/ChangeNameView.swift
+++ b/Saboteur/Features/Lobby/ChangeNameView.swift
@@ -4,6 +4,7 @@
 //
 //  Created by 이주현 on 7/15/25.
 //
+import MultipeerConnectivity
 import P2PKit
 import SwiftUI
 
@@ -20,14 +21,23 @@ struct ChangeNameView: View {
         self.onNameChanged = onNameChanged
 
         let fullName = P2PNetwork.myPeer.displayName
-        if let firstSpace = fullName.firstIndex(of: " ") {
+        if fullName.starts(with: "TEMP_USER_") {
+            _selectedCountry = State(initialValue: "🇰🇷")
+            _nickname = State(initialValue: "")
+        } else if let firstSpace = fullName.firstIndex(of: " ") {
             let flag = String(fullName[..<firstSpace])
             let name = String(fullName[fullName.index(after: firstSpace)...])
             _selectedCountry = State(initialValue: flag)
             _nickname = State(initialValue: name)
         } else {
-            _selectedCountry = State(initialValue: "🇰🇷")
-            _nickname = State(initialValue: fullName)
+            let components = fullName.split(separator: " ", maxSplits: 1).map { String($0) }
+            if components.count == 2 {
+                _selectedCountry = State(initialValue: components[0])
+                _nickname = State(initialValue: components[1])
+            } else {
+                _selectedCountry = State(initialValue: "🇰🇷")
+                _nickname = State(initialValue: fullName)
+            }
         }
     }
 
@@ -59,8 +69,16 @@ struct ChangeNameView: View {
                     Button {
                         isPresented = false
                     } label: {
-                        Image(.xButton)
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 100)
+                                .innerShadow()
+                                .foregroundStyle(nickname.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? Color.Grayscale.gray : Color.Emerald.emerald2)
+                                .frame(width: 62, height: 50)
+
+                            Image(.xButton)
+                        }
                     }
+                    .disabled(nickname.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
                 .padding(.horizontal, 24)
             }
@@ -160,31 +178,5 @@ struct ChangeNameView: View {
 #Preview {
     ChangeNameView(isPresented: .constant(true)) {
         print("닉네임 변경됨")
-    }
-}
-
-struct InnerShadowViewModifier: ViewModifier {
-    var color: Color
-    var radius: CGFloat
-    var x: CGFloat
-    var y: CGFloat
-
-    func body(content: Content) -> some View {
-        content
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(color, lineWidth: 1)
-                    .blur(radius: radius)
-                    .offset(x: x, y: y)
-                    .mask(
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(LinearGradient(
-                                colors: [.black, .clear],
-                                startPoint: .bottom,
-                                endPoint: .bottom
-                            )
-                            )
-                    )
-            )
     }
 }

--- a/Saboteur/Features/Lobby/LobbyView.swift
+++ b/Saboteur/Features/Lobby/LobbyView.swift
@@ -66,9 +66,9 @@ struct LobbyView: View {
             }
         }
         .onAppear {
-            displayName = P2PNetwork.myPeer.displayName
+            displayName = P2PNetwork.myPeer.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
 
-            if P2PNetwork.myPeer == nil {
+            if displayName.isEmpty || displayName.starts(with: "TEMP_USER_") {
                 showNameModal = true
             }
         }

--- a/Saboteur/Resources/Assets.xcassets/Button/x_button.imageset/x_button.svg
+++ b/Saboteur/Resources/Assets.xcassets/Button/x_button.imageset/x_button.svg
@@ -1,17 +1,3 @@
-<svg width="62" height="50" viewBox="0 0 62 50" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g filter="url(#filter0_i_920_736)">
-<rect width="62" height="50" rx="25" fill="#19505A"/>
-</g>
-<path d="M34.5574 16.1053C36.0311 14.6316 38.4197 14.6316 39.8933 16.1053C41.3669 17.5789 41.3669 19.9675 39.8933 21.4412L36.3357 24.9988L39.8943 28.5574C41.3679 30.0311 41.3679 32.4207 39.8943 33.8943C38.4207 35.368 36.0311 35.368 34.5574 33.8943L30.9988 30.3357L27.4412 33.8943C25.9676 35.3675 23.5788 35.3675 22.1052 33.8943C20.6316 32.4206 20.6316 30.0311 22.1052 28.5574L25.6629 24.9998L22.1052 21.4422C20.6316 19.9685 20.6317 17.579 22.1052 16.1053C23.5789 14.6316 25.9685 14.6316 27.4422 16.1053L30.9998 19.6629L34.5574 16.1053Z" fill="#FFF9E6"/>
-<defs>
-<filter id="filter0_i_920_736" x="0" y="0" width="62" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-<feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
-<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-<feOffset dy="-4"/>
-<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
-<feBlend mode="normal" in2="shape" result="effect1_innerShadow_920_736"/>
-</filter>
-</defs>
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.5574 1.10526C15.0311 -0.368363 17.4197 -0.368402 18.8933 1.10526C20.3669 2.57892 20.3669 4.96753 18.8933 6.4412L15.3357 9.99882L18.8943 13.5574C20.3679 15.0311 20.3679 17.4207 18.8943 18.8943C17.4207 20.368 15.0311 20.368 13.5574 18.8943L9.9988 15.3357L6.44119 18.8943C4.96763 20.3675 2.57883 20.3675 1.10525 18.8943C-0.368416 17.4206 -0.368416 15.0311 1.10525 13.5574L4.66287 9.9998L1.10525 6.44218C-0.368371 4.96854 -0.368279 2.57896 1.10525 1.10526C2.57891 -0.368422 4.9685 -0.368422 6.44216 1.10526L9.99978 4.66288L13.5574 1.10526Z" fill="#FFF9E6"/>
 </svg>


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #223 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 앱 최초 접속 시 닉네임 설정 모달 뷰가 열립니다. 
- 닉네임 입력값이 공백일 경우 `적용하기` 버튼 및 `닫기(X)` 버튼 비활성화 처리

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 앱 첫 실행 시 닉네임 모달 정상 표시 확인
- [x] 닉네임 미입력 시 버튼 비활성화 상태 확인
- [x] 입력 후 닉네임 적용 시 디스플레이 이름 정상 변경

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 로직은 다음과 같습니다.
-  최초 접속 시 `TEMP_USER_****` 형식의 디스플레이 이름 자동 설정 (`UUID` 앞 4글자)
- 공백이나 nil값이면 열리게 하려 했지만, Apple 정책상 `MCPeerID.displayName` 공백 불가로 인해 `nil`이나 `""` 대신 임시 이름 사용
- `TEMP_USER_`로 시작하는 유저는 로비 진입 시 **닉네임 모달 뷰**가 자동 표시됨
- peerID 저장/복원 시 `UserDefaults`를 사용함
