### PR TITLE
✨ Feat: #266 게임뷰에서 닉네임이 같으면 같은 사람으로 인식되는 오류 해결

### DIFF
--- a/P2PKit/Sources/P2PKit/P2PNetwork.swift
+++ b/P2PKit/Sources/P2PKit/P2PNetwork.swift
@@ -36,7 +36,7 @@ public struct EventInfo: Codable {
 
 public enum P2PNetwork {
     public static var maxConnectedPeers: Int = 2 // 기본 플레이 인원은 2명
-    public static var currentTurnPlayerName = P2PSyncedObservable(name: "currentTurnPlayerName", initial: "")
+    public static var currentTurnPlayerID = P2PSyncedObservable<Peer.Identifier>(name: "currentTurnPlayerID", initial: P2PNetwork.myPeer.id)
 
     private static var session = P2PSession(myPeer: Peer.getMyPeer())
     private static let sessionListener = P2PNetworkSessionListener()
@@ -209,10 +209,10 @@ extension P2PNetworkSessionListener: P2PSessionDelegate {
     func p2pSession(_: P2PSession, didUpdate peer: Peer) {
         guard !P2PNetwork.soloMode else { return }
 
-        if P2PNetwork.currentTurnPlayerName.value.isEmpty {
+        if P2PNetwork.currentTurnPlayerID.value.isEmpty {
             let candidates = [P2PNetwork.myPeer] + P2PNetwork.connectedPeers
             if let firstPlayer = candidates.randomElement() {
-                P2PNetwork.currentTurnPlayerName.value = firstPlayer.displayName
+                P2PNetwork.currentTurnPlayerID.value = firstPlayer.id
             }
         }
 

--- a/Saboteur/Features/GamePlay/GameResultView.swift
+++ b/Saboteur/Features/GamePlay/GameResultView.swift
@@ -5,6 +5,7 @@
 //  Created by 이주현 on 7/15/25.
 //
 
+import MultipeerConnectivity
 import P2PKit
 import SwiftUI
 
@@ -17,9 +18,10 @@ private let loserCardSpacing: CGFloat = 8
 
 struct GameResultView: View {
     let result: GameResult
-    let players: [String]
-    let myName: String
+    let players: [Peer]
+    let myID: Peer.Identifier
     @EnvironmentObject var router: AppRouter
+    @State private var finalPlayers: [Peer] = []
 
     var body: some View {
         VStack {
@@ -32,7 +34,7 @@ struct GameResultView: View {
                 switch result {
                 case let .winner(name):
                     ZStack {
-                        if name == myName {
+                        if name == myID {
                             Image(.resultWin)
                         } else {
                             Image(.resultLose)
@@ -45,40 +47,42 @@ struct GameResultView: View {
                 case let .winner(name):
                     VStack {
                         // 승자 카드
-                        if let winnerCard = players.first(where: { $0 == name }) {
-                            ZStack {
-                                RoundedRectangle(cornerRadius: 10)
-                                    .innerShadow()
-                                    .frame(width: winnerCardWidth, height: winnerCardHeight)
-                                    .foregroundStyle(Color.Ivory.ivory1)
+                        Group {
+                            if let winnerCard = finalPlayers.first(where: { $0.id == name }) {
+                                ZStack {
+                                    RoundedRectangle(cornerRadius: 10)
+                                        .innerShadow()
+                                        .frame(width: winnerCardWidth, height: winnerCardHeight)
+                                        .foregroundStyle(Color.Ivory.ivory1)
 
-                                HStack {
-                                    Text("WIN")
-                                        .foregroundStyle(Color.Secondary.yellow2)
-                                        .body2WideFont()
-                                    Spacer()
-                                    if winnerCard == myName {
-                                        ZStack {
-                                            RoundedRectangle(cornerRadius: 4)
-                                                .frame(width: 50, height: 20)
-                                                .foregroundStyle(Color.Etc.pink)
-                                            Text("ME")
-                                                .label2Font()
-                                                .foregroundStyle(Color.Grayscale.whiteBg)
+                                    HStack {
+                                        Text("WIN")
+                                            .foregroundStyle(Color.Secondary.yellow2)
+                                            .body2WideFont()
+                                        Spacer()
+                                        if winnerCard.id == myID {
+                                            ZStack {
+                                                RoundedRectangle(cornerRadius: 4)
+                                                    .frame(width: 50, height: 20)
+                                                    .foregroundStyle(Color.Etc.pink)
+                                                Text("ME")
+                                                    .label2Font()
+                                                    .foregroundStyle(Color.Grayscale.whiteBg)
+                                            }
                                         }
                                     }
-                                }
-                                .padding(.horizontal, 18)
-                                .frame(width: winnerCardWidth, height: winnerCardHeight)
+                                    .padding(.horizontal, 18)
+                                    .frame(width: winnerCardWidth, height: winnerCardHeight)
 
-                                Text("\(winnerCard)")
-                                    .foregroundStyle(Color.Emerald.emerald2)
-                                    .body2Font()
+                                    Text("\(winnerCard.displayName)")
+                                        .foregroundStyle(Color.Emerald.emerald2)
+                                        .body2Font()
+                                }
                             }
                         }
 
                         // 패자 카드 (플레이어 수에 따라 다르게 배치)
-                        let losers = players.filter { $0 != name }
+                        let losers = finalPlayers.filter { $0.id != name }
                         let row1 = Array(losers.prefix(2))
                         let row2 = losers.count > 2 ? [losers[2]] : []
 
@@ -93,7 +97,7 @@ struct GameResultView: View {
                                 .frame(height: loserCardHeight)
                         } else {
                             HStack(spacing: loserCardSpacing) {
-                                ForEach(row1, id: \.self) { player in
+                                ForEach(row1, id: \.id) { player in
                                     loserCard(player: player)
                                 }
                             }
@@ -151,15 +155,29 @@ struct GameResultView: View {
                 .layoutPriority(1)
         }
         .task {
-            P2PNetwork.outSession()
-            P2PNetwork.removeAllDelegates()
+            if let storedPeers = UserDefaults.standard.array(forKey: "FinalPeers") as? [[String: String]] {
+                finalPlayers = storedPeers.compactMap { dict in
+                    if let id = dict["id"], let displayName = dict["displayName"] {
+                        return Peer(MCPeerID(displayName: displayName), id: id)
+                    } else {
+                        return nil
+                    }
+                }
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                P2PNetwork.outSession()
+                P2PNetwork.removeAllDelegates()
+            }
+//            P2PNetwork.outSession()
+//            P2PNetwork.removeAllDelegates()
         }
     }
 
     private var resultTexts: [String] {
         switch result {
         case let .winner(name):
-            return players.map { $0 == name ? "\($0) 승리!" : "\($0) 패배" }
+            return finalPlayers.map { $0.id == name ? "\($0.displayName) 승리!" : "\($0.displayName) 패배" }
         }
     }
 }
@@ -168,7 +186,7 @@ struct GameResultView: View {
 
 extension GameResultView {
     @ViewBuilder
-    private func loserCard(player: String) -> some View {
+    private func loserCard(player: Peer) -> some View {
         ZStack {
             RoundedRectangle(cornerRadius: 10)
                 .foregroundStyle(Color.Ivory.ivory2)
@@ -183,7 +201,7 @@ extension GameResultView {
                     .foregroundStyle(Color.Secondary.blue1)
                     .label1Font()
                 Spacer()
-                if player == myName {
+                if player.id == myID {
                     ZStack {
                         RoundedRectangle(cornerRadius: 4)
                             .frame(width: 50, height: 20)
@@ -197,7 +215,7 @@ extension GameResultView {
             .padding(.horizontal, 14)
             .frame(width: loserCardWidth, height: loserCardHeight)
 
-            Text("\(player)")
+            Text("\(player.displayName)")
                 .foregroundStyle(Color.Emerald.emerald2)
                 .label1Font()
         }
@@ -206,7 +224,7 @@ extension GameResultView {
     }
 }
 
-#Preview {
-    GameResultView(result: .winner("🇰🇷 JudyJ"), players: ["🇰🇷 JudyJ", "🇰🇷 Nike", "🇰🇷 Nike"], myName: "🇰🇷 JudyJ")
-        .environmentObject(AppRouter())
-}
+// #Preview {
+//    GameResultView(result: .winner("🇰🇷 JudyJ"), players: ["🇰🇷 JudyJ", "🇰🇷 Nike", "🇰🇷 Nike"], myName: "🇰🇷 JudyJ")
+//        .environmentObject(AppRouter())
+// }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #266 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 사용자 식별을 `displayName`(닉네임)이 아닌 고유 ID(`Peer.id`) 기준으로 변경하여,  같은 닉네임을 가진 다른 사용자를 구분할 수 있도록 수정
- 사용자 리스트, 턴 비교, 우승자 판단 등 모든 로직에서 id 기반 비교로 일괄 변경
- `GameResultView`에서 연결이 끊긴 우승자의 정보가 누락되지 않도록  연결 끊기 전 닉네임 + id 정보를 UserDefaults에 저장하여 불러오는 방식으로 처리

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 내 턴 여부가 정확하게 표시되고, 다른 사용자 턴일 때는 차단 메시지 출력
- [x] 게임 종료 후, 연결이 끊긴 우승자 카드가 패자 화면에서도 정확하게 표시됨
- [x] UserDefaults에 저장된 peer 정보를 통해 GameResultView에서 모든 사용자 렌더링 확인
