### PR TITLE
🐛 Fix: 세션연결 후 광고-브라우져검색정지 (3, 4인 플레이 중 한명이 나간 후 제 3자가 안들어오게 하기 위함)

### DIFF
--- a/P2PKit/Sources/P2PKit/P2PNetwork.swift
+++ b/P2PKit/Sources/P2PKit/P2PNetwork.swift
@@ -96,6 +96,18 @@ public enum P2PNetwork {
 //        }
     }
 
+    // MARK: - Stop Advertising and browser
+
+    public static func stopAdvertising() {
+        session.stopAdverting()
+    }
+
+    public static func stopbrowsing() {
+        session.stopBrowsing()
+    }
+
+    // MARK: - Session Connection States
+
     public static func connectionState(for peer: MCPeerID) -> MCSessionState? {
         session.connectionState(for: peer)
     }

--- a/P2PKit/Sources/P2PKit/Private/P2PSession.swift
+++ b/P2PKit/Sources/P2PKit/Private/P2PSession.swift
@@ -97,6 +97,14 @@ class P2PSession: NSObject {
         browser.delegate = nil
     }
 
+    func stopAdverting() {
+        advertiser.stopAdvertisingPeer()
+    }
+
+    func stopBrowsing() {
+        browser.stopBrowsingForPeers()
+    }
+
     func connectionState(for peer: MCPeerID) -> MCSessionState? {
         peersLock.lock(); defer { peersLock.unlock() }
         return sessionStates[peer]

--- a/Saboteur/Features/Connect/ConnectView.swift
+++ b/Saboteur/Features/Connect/ConnectView.swift
@@ -172,6 +172,8 @@ struct ConnectView: View {
                 countdownTimer = nil
                 if connected.peers.count == P2PNetwork.maxConnectedPeers {
                     P2PNetwork.makeMeHost()
+                    P2PNetwork.stopAdvertising()
+                    P2PNetwork.stopbrowsing()
                     state = .startedGame
                 }
             }


### PR DESCRIPTION
<!--Why:
- 게임 진행 중 3명이상 방에서 1명이 나가면 대기방에 있는 유저가 조인됨

How:
- P2PKit수정 - 광고/브라우져검색종료추가
- 추가한 함수 ConnectView에 추가함
- API 할 수 있게 광고/브라우져검색 함수추가
- Tags: #태그1 #태그2 #모듈명
-->
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #270 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 광고/브라우징관련 종료 함수 추가
- API 사용 가능하게 진행함.
- 버그 수정: 게임이 시작되면 더 이상 광고/브라우징이 되지 않게 수정함.

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->
- [x] Test Case에 기본동작 체크리스트에 추가된 이슈 정리함.(이슈 번호 : C4-MT4-0024)
- [x] UI 정상 동작 확인
- [x] iPhone 16 Max, 16, 14, iOS 18.5 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- `XxxViewModel.swift` 파일의 로직 분리 구조
- `NetworkManager.swift`의 공통 로직 처리 방식