### PR TITLE
✨ Feat: #271 카드덱 자동 분배 및 세션 오류 롤백

### DIFF
--- a/P2PKit/Sources/P2PKit/P2PNetwork.swift
+++ b/P2PKit/Sources/P2PKit/P2PNetwork.swift
@@ -96,18 +96,6 @@ public enum P2PNetwork {
 //        }
     }
 
-    // MARK: - Stop Advertising and browser
-
-    public static func stopAdvertising() {
-        session.stopAdverting()
-    }
-
-    public static func stopbrowsing() {
-        session.stopBrowsing()
-    }
-
-    // MARK: - Session Connection States
-
     public static func connectionState(for peer: MCPeerID) -> MCSessionState? {
         session.connectionState(for: peer)
     }

--- a/P2PKit/Sources/P2PKit/Private/P2PSession.swift
+++ b/P2PKit/Sources/P2PKit/Private/P2PSession.swift
@@ -97,14 +97,6 @@ class P2PSession: NSObject {
         browser.delegate = nil
     }
 
-    func stopAdverting() {
-        advertiser.stopAdvertisingPeer()
-    }
-
-    func stopBrowsing() {
-        browser.stopBrowsingForPeers()
-    }
-
     func connectionState(for peer: MCPeerID) -> MCSessionState? {
         peersLock.lock(); defer { peersLock.unlock() }
         return sessionStates[peer]

--- a/Saboteur/Features/Connect/ConnectView.swift
+++ b/Saboteur/Features/Connect/ConnectView.swift
@@ -172,8 +172,6 @@ struct ConnectView: View {
                 countdownTimer = nil
                 if connected.peers.count == P2PNetwork.maxConnectedPeers {
                     P2PNetwork.makeMeHost()
-                    P2PNetwork.stopAdvertising()
-                    P2PNetwork.stopbrowsing()
                     state = .startedGame
                 }
             }

--- a/Saboteur/Features/GamePlay/GameBoardView.swift
+++ b/Saboteur/Features/GamePlay/GameBoardView.swift
@@ -53,7 +53,7 @@ struct GameBoardView: View {
                     )
 
                     CardSelectionView(
-                        cards: Array(cardSet.prefix(5)),
+                        cards: boardViewModel.getMe?.cardsInHand ?? [],
                         selectedCard: $boardViewModel.selectedCard,
                         onSelect: { card in
                             boardViewModel.selectedCard = card

--- a/Saboteur/Features/GamePlay/Models/PeerPlayer.swift
+++ b/Saboteur/Features/GamePlay/Models/PeerPlayer.swift
@@ -1,0 +1,50 @@
+import Foundation
+import P2PKit
+import SaboteurKit
+
+public struct PeerPlayer: Identifiable {
+    // MARK: - Identity
+
+    public let id = UUID()
+    public let peer: Peer
+    public let nation: String
+
+    // MARK: - Hand Management
+
+    private(set) var hand: [Card] = []
+    public let maxHandSize = 5
+
+    // 외부에서 손패를 읽기 전용으로 접근 가능
+    public var cardsInHand: [Card] { hand }
+
+    // MARK: - Actions
+
+    /// 덱에서 카드를 1장 뽑아 손패에 추가합니다.
+    public mutating func drawCard(from deck: inout Deck) {
+        guard hand.count < maxHandSize else { return }
+        if let card = deck.draw() {
+            hand.append(card)
+        }
+    }
+
+    /// 인덱스로 카드를 제거합니다.
+    public mutating func removeCard(at index: Int) -> Card? {
+        guard hand.indices.contains(index) else { return nil }
+        return hand.remove(at: index)
+    }
+
+    /// 지정한 카드를 찾아 제거합니다.
+    public mutating func discardCard(_ card: Card) -> Bool {
+        if let index = hand.firstIndex(of: card) {
+            hand.remove(at: index)
+            return true
+        }
+        return false
+    }
+
+    /// 손패를 출력합니다. (디버깅용)
+    public func display() {
+        let symbols = hand.map(\.symbol)
+        print("🃏 내 카드: \(symbols.joined(separator: " "))")
+    }
+}


### PR DESCRIPTION
다음은 주어진 diff와 메시지를 기반으로 작성한 PR 내용입니다.

## ⚓ Related Issue
- #271
- #228 

## 🥥 Contents
- PeerPlayer 모델 도입 및 BoardViewModel 내 players 배열 확장
- 게임 시작 시 자동으로 플레이어별 핸드 카드 분배
- 카드 선택 → 플레이 → 드로우까지의 흐름을 BoardViewModel 내에서 완결
- 🔁 [Revert] PR #271에서 머지된 코드로 인해 세션이 조기 종료되며 데이터 동기화가 끊기는 문제가 발생해 롤백 처리
- stopAdvertising(), stopBrowsing() 호출 제거
- 정상적인 연결 및 데이터 교환 흐름 복구

## 📸 Screenshot

https://github.com/user-attachments/assets/c1a4d7cb-d516-4e77-9438-b0ef3cd37d29


## 💬 Other information
- 문제의 원인은 PR #271 머지 후 세션을 의도치 않게 종료시키는 동작(stopAdvertising, stopBrowsing)이 포함되었기 때문입니다.
- 이번 PR에는 해당 부분의 Revert 커밋을 포함하여, 정상적인 P2P 세션 유지 및 카드 데이터 동기화가 가능하도록 복구했습니다.
- 현재는 카드 덱의 id를 symbol값을 사용하고 있어 같은 symbol을 가진 카드가 덱에 있으면 중복 선택하는 것 처럼 보입니다.