### PR TITLE
🐛Fix. 카드 설치 오류 해결 & 목적지 열 길카드 폐쇄

### DIFF
--- a/GameEngine/main.swift
+++ b/GameEngine/main.swift
@@ -97,8 +97,8 @@ while true {
             print(message)
             if success {
                 if board.grid[7][2].isCard
-                    || board.grid[8][1].isCard
-                    || board.grid[8][3].isCard
+//                    || board.grid[8][1].isCard
+//                    || board.grid[8][3].isCard
                     || board.grid[7][0].isCard
                     || board.grid[7][4].isCard
                 {

--- a/SaboteurKit/Sources/SaboteurKit/Models/Board.swift
+++ b/SaboteurKit/Sources/SaboteurKit/Models/Board.swift
@@ -40,6 +40,8 @@ public class Board {
     // 카드 설치 가능 여부를 확인한다 - 로직 위주
        public func isPlacable(x: Int, y: Int, card: Card) -> Bool {
            guard x >= 0, x < 9, y >= 0, y < 5 else { return false } // 카드를 설치할 값의 위치가 좌표 위가 아니라면 false
+           
+           if x == 8 { return false }
 
            var trueConnectedCount = 0
            let directions = [(-1, 0, 3, 1), (1, 0, 1, 3), (0, -1, 0, 2), (0, 1, 2, 0)]

--- a/SaboteurKit/Sources/SaboteurKit/Models/Board.swift
+++ b/SaboteurKit/Sources/SaboteurKit/Models/Board.swift
@@ -50,20 +50,18 @@ public class Board {
                guard nx >= 0, nx < 9, ny >= 0, ny < 5 else { continue } // neighbor 카드의 존재 여부 체크
                let neighbor = grid[nx][ny]
                
-               
                if isGoalLine(x: nx, y: ny) ? (neighbor.isOpened == true) : neighbor.isCard {
                    if card.directions[myDir], neighbor.directions[neighborDir] {
+//                       print("연결 발생 \(x),\(y) - myDir:\(myDir),\(card.directions[myDir]) / \(nx),\(ny) - neighborDir:\(neighborDir),\(neighbor.directions[neighborDir])")
                        trueConnectedCount += 1
-                       if isGoalLine(x: nx, y: ny) && (neighbor.isOpened == false) {
-                           trueConnectedCount -= 1
-                       }
                    } else if card.directions[myDir] != neighbor.directions[neighborDir] {
-                       return false // 연결이 안 맞는 방향이 하나라도 있으면 false
+//                       print("연결오류 발생 \(x),\(y) / \(nx),\(ny)")
+                       return false
                    }
                }
            }
 
-           return trueConnectedCount > 0 // true-true인 방향이 있어야 한 개 이상 있으면 true
+           return trueConnectedCount > 0 // true-true인 방향이 한 개 이상 있어야 true
        }
 
        // 카드를 설치한다 - 기본적인 isCard나 시작, 도착 지점 여부 확인도 이루어진다

--- a/SaboteurKit/Sources/SaboteurKit/Models/Card.swift
+++ b/SaboteurKit/Sources/SaboteurKit/Models/Card.swift
@@ -33,7 +33,7 @@ public let cardSet: [Card] = [
     // 연결 가능한 길 카드
     Card(directions: [true, false, false, true], connect: true, symbol: "┘", imageName: "Card/Road/tl"), // tl
     Card(directions: [true, true, false, false], connect: true, symbol: "└", imageName: "Card/Road/tr"), // tr
-    Card(directions: [true, false, true, true], connect: true, symbol: "│", imageName: "Card/Road/tb"), // tb
+    Card(directions: [true, false, true, false], connect: true, symbol: "│", imageName: "Card/Road/tb"), // tb
     Card(directions: [false, true, false, true], connect: true, symbol: "─", imageName: "Card/Road/rl"), // rl
     Card(directions: [true, true, true, false], connect: true, symbol: "├", imageName: "Card/Road/trb"), // trb
     Card(directions: [true, true, false, true], connect: true, symbol: "ㅗ", imageName: "Card/Road/trl"), // trl
@@ -44,7 +44,7 @@ public let cardSet: [Card] = [
     Card(directions: [false, false, false, true], connect: false, symbol: "◀︎", imageName: "Card/Road/l_block"), // l_block
     Card(directions: [true, false, false, true], connect: false, symbol: "▴◀︎", imageName: "Card/Road/tl_block"), // tl_block
     Card(directions: [true, true, false, false], connect: false, symbol: "╰", imageName: "Card/Road/tr_block"), // tr_block
-    Card(directions: [true, false, true, true], connect: false, symbol: "▴▾", imageName: "Card/Road/tb_block"), // tb_block
+    Card(directions: [true, false, true, false], connect: false, symbol: "▴▾", imageName: "Card/Road/tb_block"), // tb_block
     Card(directions: [false, true, false, true], connect: false, symbol: "◀︎‣", imageName: "Card/Road/rl_block"), // rl_block
     Card(directions: [true, true, true, false], connect: false, symbol: "▴‣▾", imageName: "Card/Road/trb_block"), // trb_block
     Card(directions: [true, true, false, true], connect: false, symbol: "▴‣◀︎", imageName: "Card/Road/trl_block"), // trl_block


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #236

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 목적지 열 isPlacable 체크 시 false 반환
- goalCheck 조건에서 목적지 열 길카드 자리 제외
- Card 중 directions 오류 해결 -> 카드 설치 오류 해결

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">
<img width="300" alt="목적지 열 길카드 설치시 false 반환" src="https://github.com/user-attachments/assets/ea375f1a-1473-4088-bf15-72c5049fe3ab" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 카드 설치 정상 작동 확인
- [x] 목적지 열 길카드 설치 불가 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 이후 목적지 열 길카드를 사용하게 될 때를 위해 관련된 코드 주석처리 해두었습니다.
- 카드 설치 오류의 주된 이유는 card의 directions가 잘못 작성되어 있던 것 입니다.
- Board.swift의 삭제된 기존 57-59번열은 상위 if 조건에서 허용되지 않는 의미없는 조건문이라 삭제했습니다.