### PR TITLE
✨ Feature: #296 맵 카드 사용 시 Toast 타겟 구분 및 카드 시각적 피드백 기능 추가

### DIFF
--- a/Saboteur/Features/Enums/ToastTarget.swift
+++ b/Saboteur/Features/Enums/ToastTarget.swift
@@ -1,0 +1,12 @@
+//
+//  ToastTarget.swift
+//  Saboteur
+//
+//  Created by kirby on 7/26/25.
+//
+
+enum ToastTarget: String, Codable {
+    case personal // 본인에게만 표시
+    case global // 모두에게 표시
+    case other // 본인을 제외한 다른 플레이어에게 표시
+}

--- a/Saboteur/Features/GamePlay/Component/BoardGridView.swift
+++ b/Saboteur/Features/GamePlay/Component/BoardGridView.swift
@@ -7,6 +7,7 @@ struct BoardGridView: View {
     let cursor: (Int, Int)?
     let onTapCell: (Int, Int) -> Void
     let latestPlacedCoord: Coordinate? // 가장 최근에 놓인 카드 위치
+    let temporarilyRevealedCell: (x: Int, y: Int)?
 
     // MARK: - Grid Layout
 
@@ -35,6 +36,7 @@ struct BoardGridView: View {
                     cell: cell(at: x, y),
                     isCursor: isCursor(at: x, y),
                     isLatestPlaced: latestPlacedCoord == Coordinate(x: x, y: y),
+                    showRevealedGoalImage: temporarilyRevealedCell?.x == x && temporarilyRevealedCell?.y == y,
                     onTap: { onTapCell(x, y) }
                 )
             }

--- a/Saboteur/Features/GamePlay/Component/GridCellView.swift
+++ b/Saboteur/Features/GamePlay/Component/GridCellView.swift
@@ -7,6 +7,7 @@ struct GridCellView: View {
     let cell: BoardCell
     let isCursor: Bool
     let isLatestPlaced: Bool // 가장 최근에 놓인 카드에 두께를 주기 위함
+    let showRevealedGoalImage: Bool
     let onTap: () -> Void
 
     // MARK: - Semantic Helpers
@@ -64,10 +65,15 @@ struct GridCellView: View {
     var imageLayer: some View {
         Group {
             if cell.type?.category == .goal, !(cell.isOpened ?? false) {
-                Image(
-                    "Card/Goal/hidden"
-                ).resizable()
-                    .aspectRatio(contentMode: .fit)
+                if showRevealedGoalImage {
+                    Image(cell.type!.imageName) // 실제 이미지 표시
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                } else {
+                    Image("Card/Goal/hidden")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                }
             } else {
                 if let imageName = cell.type?.imageName {
                     Image(
@@ -88,14 +94,4 @@ struct GridCellView: View {
             }
         }
     }
-}
-
-#Preview {
-    GridCellView(
-        x: 0, y: 0,
-        cell: BoardCell(type: CardType.blockTB),
-        isCursor: false,
-        isLatestPlaced: true,
-        onTap: { print("Tapped") }
-    )
 }

--- a/Saboteur/Features/GamePlay/GameBoardView.swift
+++ b/Saboteur/Features/GamePlay/GameBoardView.swift
@@ -159,7 +159,8 @@ struct GameBoardView: View {
                             boardViewModel.cursor = (x, y)
                             boardViewModel.placeSelectedCard()
                         },
-                        latestPlacedCoord: boardViewModel.latestPlacedCoord.value
+                        latestPlacedCoord: boardViewModel.latestPlacedCoord.value,
+                        temporarilyRevealedCell: boardViewModel.revealedGoalCell
                     )
                     HStack(spacing: 24) {
                         Button(action: {

--- a/Saboteur/Features/GamePlay/GameBoardView.swift
+++ b/Saboteur/Features/GamePlay/GameBoardView.swift
@@ -60,8 +60,8 @@ struct GameBoardView: View {
                             if let remaining = allPeers.first(where: { $0.id != myID }) {
                                 winner.value = remaining.id
                             }
-                            let myDisplayName = P2PNetwork.myPeer.displayName
-                            exitToastMessage.value = "\(myDisplayName)님이 나가서 게임이 강제 종료되었습니다"
+
+                            exitToastMessage.value = "\(boardViewModel.myName)님이 나가서 게임이 강제 종료되었습니다"
                         }
                         router.currentScreen = .choosePlayer
 

--- a/Saboteur/Features/GamePlay/GameBoardViewModel.swift
+++ b/Saboteur/Features/GamePlay/GameBoardViewModel.swift
@@ -89,6 +89,10 @@ final class BoardViewModel: ObservableObject {
         players.first(where: { $0.peer.id == P2PNetwork.myPeer.id })
     }
 
+    var myName: String {
+        getMe?.peer.displayName ?? "Anonymous"
+    }
+
     // MARK: - 초기화
 
     /// 연결된 Peer를 기반으로 플레이어 목록 구성
@@ -188,8 +192,8 @@ final class BoardViewModel: ObservableObject {
 
     /// 일반 카드 처리
     private func handleNormalCard(_ card: Card, at pos: (Int, Int), playerIndex: Int) {
-        let (success, message) = board.placeCard(x: pos.0, y: pos.1, card: card, player: currentPlayer.value)
-        showToast(message)
+        let (success, message) = board.placeCard(x: pos.0, y: pos.1, card: card, player: myName)
+        sendToast(message, target: .global)
         guard success else { return }
 
         // 1) 로컬 보드에 카드 반영
@@ -296,8 +300,8 @@ final class BoardViewModel: ObservableObject {
             // 2) 공개된 goal 카드 정보를 P2P로 전파
             syncGoalOpenStates()
 
-            // 3) 토스트 알림
-            showToast("🎉 \(currentPlayer.value)가 길을 완성했습니다!")
+            // 3) 토스트 알림let myName = getMe?.peer.displayName ?? "Anonymous"
+            sendToast("🎉 \(myName)가 길을 완성했습니다!", target: .global)
 
             // 4) 2초 후 승패 동기화
             DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {

--- a/Saboteur/Features/GamePlay/GameBoardViewModel.swift
+++ b/Saboteur/Features/GamePlay/GameBoardViewModel.swift
@@ -17,6 +17,7 @@ final class BoardViewModel: ObservableObject {
 
     @Published var currentPlayer: P2PSyncedObservable<Peer.Identifier> = P2PNetwork.currentTurnPlayerID
     @Published var placedCards = P2PSyncedObservable(name: "PlacedCards", initial: [String: BoardCell]())
+    @Published var revealedGoalCell: (x: Int, y: Int)? = nil
 
     let latestPlacedCoord = P2PSyncedObservable<Coordinate?>(name: "LatestCoord", initial: nil)
 
@@ -168,8 +169,14 @@ final class BoardViewModel: ObservableObject {
             return
         }
 
-        // 1. 나만 보는 메시지
-        showToast("🗺 이 카드는 \(isGoal ? "🎯 진짜 Goal" : "❌ 가짜 Goal")입니다.")
+        // 1. 나만 보는 UI 업데이트
+        // ✅ 보여줄 좌표 설정
+        revealedGoalCell = (x, y)
+
+        // ✅ 2초 뒤에 감추기
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            self.revealedGoalCell = nil
+        }
 
         // 2. 나를 제외한 모두에게 알림
         let myName = P2PNetwork.myPeer.displayName

--- a/Saboteur/Features/GamePlay/Models/Coordinate.swift
+++ b/Saboteur/Features/GamePlay/Models/Coordinate.swift
@@ -1,0 +1,11 @@
+//
+//  Coordinate.swift
+//  Saboteur
+//
+//  Created by kirby on 7/26/25.
+//
+
+struct Coordinate: Codable, Equatable {
+    let x: Int
+    let y: Int
+}

--- a/Saboteur/Features/GamePlay/Models/TargetedToast.swift
+++ b/Saboteur/Features/GamePlay/Models/TargetedToast.swift
@@ -1,0 +1,12 @@
+//
+//  TargetedToast.swift
+//  Saboteur
+//
+//  Created by kirby on 7/26/25.
+//
+
+struct TargetedToast: Codable, Equatable {
+    let message: String
+    let target: ToastTarget
+    let senderID: String
+}


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #296 맵 카드 사용 시 Toast 타겟 구분 및 카드 시각적 피드백 기능 추가
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- #296 
- #291

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

P2P 멀티플레이 환경에서 map 카드 사용 시, 정보 공유의 범위를 조절하고 본인에겐 시각적 피드백을 제공하는 기능을 도입했습니다.
이를 통해 UX가 개선되었으며, 메시지 전달 방식도 명확히 분리되었습니다.

1. ToastTarget 구분 도입
- personal, global, other로 메시지 타겟 구분 (personal은 현재로썬 거의 사용하지 않습니다.)
- 새로운 모델 TargetedToast 구성

2. BoardViewModel 리팩토링
- sendToast() 메서드로 글로벌 메시지 전송 통일
- myName 프로퍼티로 displayName 접근 방식 개선 이제 UUID가 아닌 플레이어 닉네임이 보입니다.
- map 카드 관련 UI 상태값(revealedGoalCell) 도입

3. GameBoardView 적용
- revealedGoalCell이 설정되면 해당 goal 카드가 2초간 공개됨
- 토스트 메시지는 타겟 대상에 따라 조건부로 표시됨
---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

https://github.com/user-attachments/assets/e06a89cc-99e8-4ef3-99e2-731cc2ad76ee

https://github.com/user-attachments/assets/6dc00321-50d2-44fc-9c93-60ab2f2a15e9

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->
- [x] map 카드 본인 UI에만 goal 공개됨
- [x] Toast 메시지 타겟별 조건부 표시
- [x] 타인이 map 카드 사용 시 토스트 수신됨
- [x] 길 완성 시 글로벌 메시지 표시됨

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- #291 위에서 작업한 PR입니다.

| 상황          | 기존                            | 개선 후                                   |
| ----------- | ----------------------------- | -------------------------------------- |
| map 카드 사용 시 | 본인: Toast 메시지 표시타인: 아무 피드백 없음 | 본인: goal 카드 이미지 2초간 노출타인: Toast 메시지 표시 |
| 일반 카드 배치    | 메시지 로컬 표시                     | 모든 플레이어에게 동기화된 메시지 전달                  |
| 길 완성        | 로컬 메시지 표시                     | 글로벌 Toast 메시지로 전파                      |


---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- 유저가 보드 위에 card를 놓으면 global toast메시지를 통해 세션에 참여된 모든 플레이어에게 공유됩니다.