### PR TITLE
🎨 Design: #292 대기방 3분 대기 팝업 디자인 입힘 및 컴포넌트화

### DIFF
--- a/Saboteur/Features/Component/PopupShadow.swift
+++ b/Saboteur/Features/Component/PopupShadow.swift
@@ -1,0 +1,98 @@
+//
+//  PopupShadow.swift
+//  Saboteur
+//
+//  Created by 이주현 on 7/26/25.
+//
+
+import SwiftUI
+
+extension View {
+    func modalOverlay<ModalView: View>(
+        isPresented: Binding<Bool>,
+        @ViewBuilder modalView: @escaping () -> ModalView
+    ) -> some View {
+        overlay {
+            if isPresented.wrappedValue {
+                ZStack {
+                    Color.black.opacity(0.4)
+                        .ignoresSafeArea()
+
+                    modalView()
+                        .background(Color.Ivory.ivory1)
+                        .cornerRadius(16)
+                        .shadow(radius: 10)
+                }
+            }
+        }
+    }
+}
+
+struct PopupView: View {
+    let popupText: String
+    var popupAction: () -> Void = {}
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // 상단 헤더
+            StrokedText(
+                text: "경고",
+                strokeWidth: 9,
+                strokeColor: .white,
+                foregroundColor: UIColor(Color.Emerald.emerald2),
+                font: UIFont(name: "MaplestoryOTFBold", size: 33)!,
+                numberOfLines: 1,
+                kerning: 0,
+                // lineHeight: 10,
+                textAlignment: .center
+            )
+            .padding(.vertical, 11)
+            .padding(.horizontal, 156)
+            .background(Color.Emerald.emerald3)
+
+            // 본문
+            VStack(alignment: .center, spacing: 10) {
+                Text(popupText)
+                    .lineLimit(nil) // 무제한 줄
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .lineSpacing(3)
+            }
+            .label1Font()
+            .foregroundStyle(Color.Emerald.emerald2)
+            .padding(.vertical, 35)
+            .padding(.horizontal, 70.5)
+
+            Spacer()
+
+            // 하단 버튼
+            HStack {
+                Spacer()
+
+                FooterButton(action: {
+                    popupAction()
+                }, title: "확인")
+                    .frame(width: 146)
+
+                Spacer()
+            }
+            .padding(.vertical, 6)
+            .padding(.horizontal, 102)
+            .background(Color.Ivory.ivory2)
+        }
+        .padding(0)
+        .frame(width: 380, height: 250)
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.black.opacity(0.4)
+            .ignoresSafeArea()
+
+        PopupView(popupText: "대기 시간이 초과되어\n인원 설정 화면으로 이동합니다.")
+            .background(Color.Ivory.ivory1)
+            .cornerRadius(16)
+            .shadow(radius: 10)
+    }
+}

--- a/Saboteur/Features/Connect/ConnectView.swift
+++ b/Saboteur/Features/Connect/ConnectView.swift
@@ -148,17 +148,13 @@ struct ConnectView: View {
                 idleTime = 0
             }
         }
-        .alert("5분 동안 연결되지 않았습니다. 인원 설정 화면으로 돌아가시겠습니까?", isPresented: $showExitAlert) {
-            Button("네", role: .destructive) {
+        .modalOverlay(isPresented: $showExitAlert, modalView: {
+            PopupView(popupText: "대기 시간이 초과되어\n인원 설정 화면으로 이동합니다.") {
                 P2PNetwork.outSession()
                 P2PNetwork.removeAllDelegates()
                 router.currentScreen = .choosePlayer
             }
-            Button("아니오", role: .cancel) {
-                idleTime = 0
-                startIdleTimer()
-            }
-        }
+        })
     }
 
     private func startCountdown() {

--- a/Saboteur/Features/Lobby/LobbyView.swift
+++ b/Saboteur/Features/Lobby/LobbyView.swift
@@ -1,11 +1,6 @@
 import P2PKit
 import SwiftUI
 
-// func setupP2PKit(channel: String) {
-//    P2PConstants.networkChannelName = channel
-//    P2PConstants.loggerEnabled = true
-// }
-
 struct LobbyView: View {
     @StateObject private var viewModel = LobbyViewModel()
 
@@ -46,22 +41,9 @@ struct LobbyView: View {
                                      },
                                      title: "게임 시작")
                             .customPadding(.footer)
-
-//                        Button {
-//
-//
-//                            startIsSelected = true
-//                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-//                                startIsSelected = false
-//                            }
-//                        } label: {
-//                            FooterButton(title: "게임 시작")
-//
-//                        }
                     }
 
                     Spacer()
-//                        .frame(height: UIScreen.main.bounds.height * 0.08)
                 }
             }
         }
@@ -72,38 +54,11 @@ struct LobbyView: View {
                 showNameModal = true
             }
         }
-        .overlay {
-            if showNameModal {
-                ZStack {
-                    Color.black.opacity(0.4)
-                        .ignoresSafeArea()
-
-                    ChangeNameView(isPresented: $showNameModal) {
-                        displayName = P2PNetwork.myPeer.displayName
-                        showNameModal = false
-                    }
-                    .background(Color.Ivory.ivory1)
-                    .cornerRadius(16)
-                    .shadow(radius: 10)
-                }
+        .modalOverlay(isPresented: $showNameModal) {
+            ChangeNameView(isPresented: $showNameModal) {
+                displayName = P2PNetwork.myPeer.displayName
+                showNameModal = false
             }
         }
     }
 }
-
-#Preview {
-    LobbyView()
-        .environmentObject(AppRouter())
-}
-
-// struct LobbyView_Preview: PreviewProvider {
-//    static var devices = ["iPhone 11", "iPhone 16 Pro Max", "iPad Pro 13-inch"]
-//    static var previews: some View {
-//        ForEach(devices, id: \.self) { device in
-//            LobbyView()
-//                .environmentObject(AppRouter())
-//                .previewDevice(PreviewDevice(rawValue: device))
-//                .previewDisplayName(device)
-//        }
-//    }
-// }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #292 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 팝업 디자인 입힘
- 기존 닉네임 모달뷰와 같은 모달 쉐도우를 사용하여 컴포넌트함 (PopupShadow 참고)

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

https://github.com/user-attachments/assets/fcf16c68-b5c1-460b-b7ea-330908b39211


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 팝업 정상 작동 확인 (스크린샷의 경우 인증을 위해 임의로 시간을 줄였지만 3분 대기하면 뜨도록 설정했습니다)
- [x] 확인 버튼 정상 동작 확인
- [x] 컴포넌트 적용한 닉네임 모달뷰에서도 정상 동작 확인
