### PR TITLE
✨Feature: #236 마지막 열 카드 설치 제한

### DIFF
--- a/GameEngine/main.swift
+++ b/GameEngine/main.swift
@@ -80,7 +80,7 @@ while true {
         guard let input = readLine(),
               let x = Int(input.split(separator: " ")[0]),
               let y = Int(input.split(separator: " ")[1]),
-              x >= 0, x < 9, y >= 0, y < 5
+              x >= 0, x < 8, y >= 0, y < 5
         else {
             print("❌ 잘못된 입력입니다.")
             continue

--- a/SaboteurKit/Sources/SaboteurKit/Models/Board.swift
+++ b/SaboteurKit/Sources/SaboteurKit/Models/Board.swift
@@ -1,5 +1,3 @@
-
-
 import Foundation
 
 public class Board {
@@ -31,12 +29,11 @@ public class Board {
         print("")
     }
 
-
     /// 해당 좌표가 목적지 라인인지 확인
     public func isGoalLine(x: Int, y: Int) -> Bool {
         Board.goalPositions.contains(where: { $0.0 == x && $0.1 == y })
     }
-    
+
     public func mapCheck(x: Int, y: Int) -> (Bool, String) {
         if isGoalLine(x: x, y: y) == false {
             return (false, "해당 지점은 확인할 수 없습니다.")
@@ -135,11 +132,7 @@ public class Board {
     }
 
     public func goalCheck() -> Bool {
-        // 로직 오류러 인해 테스트를 위하여 임시 추가
-        // goal영역 근처에 도달하면 자동 실행
-        return true
-
-        print("🔍 goalCheck 시작: start 위치에서 탐색을 시작합니다.")
+        // print("🔍 goalCheck 시작: start 위치에서 탐색을 시작합니다.")
         var visited = Array(
             repeating: Array(repeating: false, count: grid[0].count),
             count: grid.count
@@ -152,26 +145,25 @@ public class Board {
         ]
         func dfs(x: Int, y: Int) -> Bool {
             guard x >= 0, x < grid.count, y >= 0, y < grid[0].count else {
-                print("⚠️ (\(x),\(y))는 보드 범위를 벗어났습니다.")
+                // print("⚠️ (\(x),\(y))는 보드 범위를 벗어났습니다.")
                 return false
             }
             guard !visited[x][y] else {
-                print("🔄 (\(x),\(y))는 이미 방문했습니다.")
+                // print("🔄 (\(x),\(y))는 이미 방문했습니다.")
                 return false
             }
             visited[x][y] = true
-            print("🚶‍♂️ 방문: (\(x),\(y)), 심볼: \(grid[x][y].symbol)")
+            // print("🚶‍♂️ 방문: (\(x),\(y)), 심볼: \(grid[x][y].symbol)")
 
             if isGoalLine(x: x, y: y), grid[x][y].isOpened == false {
                 lastGoal = (x, y)
-                print("🎯 목표에 도달했습니다! (\(x),\(y))")
-                grid[x][y].isOpened = true // ✅ goal 카드를 공개 처리
+                // print("🎯 목표에 도달했습니다! (\(x),\(y))")
                 return true
             }
 
             let cell = grid[x][y]
             guard cell.isConnect else {
-                print("❌ (\(x),\(y))는 연결 가능한 카드가 아닙니다.")
+                // print("❌ (\(x),\(y))는 연결 가능한 카드가 아닙니다.")
                 return false
             }
 
@@ -179,13 +171,11 @@ public class Board {
                 let nx = x + dx, ny = y + dy
                 if nx >= 0, nx < grid.count, ny >= 0, ny < grid[0].count {
                     let neigh = grid[nx][ny]
-
                     let isGoal = isGoalLine(x: nx, y: ny) && grid[nx][ny].isOpened == false
-
                     let canConnect = cell.directions[myDir]
                         && (isGoal || (neigh.isCard && neigh.isConnect))
                         && neigh.directions[neighDir]
-                    print("➡️ 연결 검사: (\(x),\(y)) -> (\(nx),\(ny)) : \(canConnect ? "가능" : "불가능")")
+                    // print("➡️ 연결 검사: (\(x),\(y)) -> (\(nx),\(ny)) : \(canConnect ? "가능" : "불가능")")
                     if canConnect {
                         if dfs(x: nx, y: ny) {
                             return true

--- a/SaboteurKit/Sources/SaboteurKit/Models/Board.swift
+++ b/SaboteurKit/Sources/SaboteurKit/Models/Board.swift
@@ -81,7 +81,7 @@ public class Board {
 
     // 카드 설치 가능 여부를 확인한다 - 로직 위주
     public func isPlacable(x: Int, y: Int, card: Card) -> Bool {
-        guard x >= 0, x < 9, y >= 0, y < 5 else { return false }
+        guard x >= 0, x < 8, y >= 0, y < 5 else { return false }
 
         var trueConnectedCount = 0
         let directions = [(-1, 0, 3, 1), (1, 0, 1, 3), (0, -1, 0, 2), (0, 1, 2, 0)]

--- a/SaboteurKit/Sources/SaboteurKit/Models/Card.swift
+++ b/SaboteurKit/Sources/SaboteurKit/Models/Card.swift
@@ -17,7 +17,7 @@ public enum CardType: String, Codable, Hashable, CaseIterable, Sendable {
     case blockTRB, blockTRL, blockTRBL
 
     // 길 카드 180도 회전
-    case pathB, pathBL, pathRB, pathRBL, pathTBL
+    case pathBL, pathRB, pathRBL, pathTBL
 
     // 방해 카드 180도 회전
     case blockB, blockBL, blockR, blockRB, blockRBL, blockTBL
@@ -49,7 +49,7 @@ public extension CardType {
         case .start,
              .pathTL, .pathTR, .pathTB, .pathRL,
              .pathTRB, .pathTRL, .pathTRBL,
-             .pathB, .pathBL, .pathRB, .pathRBL, .pathTBL,
+             .pathBL, .pathRB, .pathRBL, .pathTBL,
              .blockT, .blockL, .blockTL, .blockTR, .blockTB, .blockRL,
              .blockTRB, .blockTRL, .blockTRBL,
              .blockB, .blockBL, .blockR, .blockRB, .blockRBL, .blockTBL:
@@ -69,7 +69,6 @@ public extension CardType {
         case .pathTRB: [true, true, true, false]
         case .pathTRL: [true, true, false, true]
         case .pathTRBL: [true, true, true, true]
-        case .pathB: [false, false, true, false]
         case .pathBL: [false, false, true, true]
         case .pathRB: [false, true, true, false]
         case .pathRBL: [false, true, true, true]
@@ -78,7 +77,7 @@ public extension CardType {
         case .blockL: [false, false, false, true]
         case .blockTL: [true, false, false, true]
         case .blockTR: [true, true, false, false]
-        case .blockTB: [true, false, true, true]
+        case .blockTB: [true, false, true, false]
         case .blockRL: [false, true, false, true]
         case .blockTRB: [true, true, true, false]
         case .blockTRL: [true, true, false, true]
@@ -99,7 +98,7 @@ public extension CardType {
     var connect: Bool {
         switch self {
         case .pathTL, .pathTR, .pathTB, .pathRL,
-             .pathTRB, .pathTRL, .pathTRBL, .pathB,
+             .pathTRB, .pathTRL, .pathTRBL,
              .pathBL, .pathRB, .pathRBL, .pathTBL,
              .start, .goalTrue, .goalFalse:
             return true
@@ -132,7 +131,6 @@ public extension CardType {
         case .blockTRB: "▴‣▾"
         case .blockTRL: "▴‣◀︎"
         case .blockTRBL: "╳"
-        case .pathB: "▾"
         case .pathBL: "◀︎▾"
         case .pathRB: "‣▾"
         case .pathRBL: "‣▾◀︎"
@@ -165,7 +163,6 @@ public extension CardType {
         case .blockTRB: "Card/Road/trb_block"
         case .blockTRL: "Card/Road/trl_block"
         case .blockTRBL: "Card/Road/trbl_block"
-        case .pathB: "Card/Road/b"
         case .pathBL: "Card/Road/bl"
         case .pathRB: "Card/Road/rb"
         case .pathRBL: "Card/Road/rbl"


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #236

---

### 🧶 주요 변경 내용 (Summary)

- isPlacable 및 카드 설치 위치 입력 조건 x<8로 변경
- goalCheck 로직 복구
- CardType 중 pathB 삭제
- blockTB directions 오류 수정
---

### 📸 스크린샷 (Optional)

<img width="443" height="284" alt="8열에 카드 설치 시 불가 표기" src="https://github.com/user-attachments/assets/83460097-2ea9-47ee-acfa-9901b1e99c6a" />


---

### 🧪 테스트 / 검증 내역

- [x] CLI 정상 동작 확인
- [x] app build success 확인
- [x] x=8열에 카드 설치시 false 반환 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- goalCheck는 진짜 goal 연결에 대한 check가 아닌, 길 완성에 대한 check입니다. 따라서 main에서는 진짜 goal인지 다시 확인을 하고(board.lastGrid값을 이용), 아니라면 isOpened = true, type.pathTRBL 처리를 합니다.

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- goalCheck function 수정 필요 사항 있는지 말씀해주세요!