### PR TITLE
✨Feature. launch screen 추가

### DIFF
--- a/Saboteur.xcodeproj/project.pbxproj
+++ b/Saboteur.xcodeproj/project.pbxproj
@@ -879,6 +879,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationLandscapeLeft;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationLandscapeLeft;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -911,6 +912,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationLandscapeLeft;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationLandscapeLeft;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;

--- a/Saboteur/Info.plist
+++ b/Saboteur/Info.plist
@@ -2,13 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIAppFonts</key>
-    <array>
-        <string>Maplestory OTF Bold.otf</string>
-        <string>Maplestory OTF Light.otf</string>
-    </array>
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>This application will use local networking to discover nearby devices.</string>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_my-p2p-2p._tcp</string>
@@ -17,6 +10,11 @@
 		<string>_my-p2p-3p._udp</string>
 		<string>_my-p2p-4p._tcp</string>
 		<string>_my-p2p-4p._udp</string>
+	</array>
+	<key>UIAppFonts</key>
+	<array>
+		<string>Maplestory OTF Bold.otf</string>
+		<string>Maplestory OTF Light.otf</string>
 	</array>
 </dict>
 </plist>

--- a/Saboteur/Info.plist
+++ b/Saboteur/Info.plist
@@ -16,5 +16,7 @@
 		<string>Maplestory OTF Bold.otf</string>
 		<string>Maplestory OTF Light.otf</string>
 	</array>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>This application will use local networking to discover nearby devices.</string>
 </dict>
 </plist>

--- a/Saboteur/Resources/Base.lproj/LaunchScreen.storyboard
+++ b/Saboteur/Resources/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_12" orientation="landscape" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" ambiguous="YES" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="852" height="393"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Logo" id="DLF-uK-VNn">
+                                <rect key="frame" x="220" y="125" width="412" height="128"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                            </imageView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="DLF-uK-VNn" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="7rz-30-TMi"/>
+                            <constraint firstItem="DLF-uK-VNn" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="S7h-7w-sei"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="52.816901408450704" y="374.80916030534348"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="Logo" width="3399" height="1168"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- non, add launch screen

---

### 🧶 주요 변경 내용 (Summary)

- Resources 그룹에 LaunchScreen.storyboard 파일추가
- Saboteur 앱 타겟의 General → App Icons and Launch Screens → Launch Screen File에 LaunchScreen 지정

---

### 📸 스크린샷 (Optional)

https://github.com/user-attachments/assets/4df678f8-1bbf-4bc4-b295-536df814ed31
<img width="500" alt="런치스크린 정상 동작" src="https://github.com/user-attachments/assets/3069d559-62ca-4346-8fa4-72ed2ff07ad6" />


---

### 🧪 테스트 / 검증 내역

- [x] 앱 실행 시 Launch Screen 정상 표시 확인
- [x] 앱 정상 동작 확인

---

### 💬 기타 공유 사항

- 추후 디자인 변경 시 해당 스토리보드에서 바로 수정 가능
- 비에라가 만든 코드이기때문에 승인 받으면 assign 비에라가 할 수 있게 해뒀습니다~~

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)

- General 탭의 Launch Screen File 설정 위치