### PR TITLE
♻️ Refact. 게임뷰모델 x, y string을 coordinate로 변경

### DIFF
--- a/Saboteur/Features/GamePlay/Component/BoardGridView.swift
+++ b/Saboteur/Features/GamePlay/Component/BoardGridView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct BoardGridView: View {
     let board: [[BoardCell]]
-    let placedCards: [String: BoardCell]
+    let placedCards: [Coordinate: BoardCell]
     var cursor: (Int, Int)? = (1, 2)
     let onTapCell: (Int, Int) -> Void
     let latestPlacedCoord: Coordinate? // 가장 최근에 놓인 카드 위치
@@ -26,7 +26,7 @@ struct BoardGridView: View {
 
     init(
         board: [[BoardCell]],
-        placedCards: [String: BoardCell],
+        placedCards: [Coordinate: BoardCell],
         cursor: (Int, Int)? = (1, 2),
         onTapCell: @escaping (Int, Int) -> Void,
         latestPlacedCoord: Coordinate?,
@@ -66,8 +66,7 @@ struct BoardGridView: View {
     }
 
     private func cell(at x: Int, _ y: Int) -> BoardCell {
-        let key = "\(x),\(y)"
-        return placedCards[key] ?? board[x][y]
+        placedCards[Coordinate(x: x, y: y)] ?? board[x][y]
     }
 
     private func isCursor(at x: Int, _ y: Int) -> Bool {

--- a/Saboteur/Features/GamePlay/GameBoardViewModel.swift
+++ b/Saboteur/Features/GamePlay/GameBoardViewModel.swift
@@ -16,7 +16,7 @@ final class BoardViewModel: ObservableObject {
     @Published var players: [PeerPlayer] = []
 
     @Published var currentPlayer: P2PSyncedObservable<Peer.Identifier> = P2PNetwork.currentTurnPlayerID
-    @Published var placedCards = P2PSyncedObservable(name: "PlacedCards", initial: [String: BoardCell]())
+    @Published var placedCards = P2PSyncedObservable(name: "PlacedCards", initial: [Coordinate: BoardCell]())
     @Published var revealedGoalCell: (x: Int, y: Int)? = nil
 
     let latestPlacedCoord = P2PSyncedObservable<Coordinate?>(name: "LatestCoord", initial: nil)
@@ -232,7 +232,7 @@ final class BoardViewModel: ObservableObject {
         for (gx, gy) in Board.goalPositions {
             let cell = board.grid[gx][gy]
             if cell.isOpened == true {
-                placedCards.value["\(gx),\(gy)"] = cell
+                placedCards.value[Coordinate(x: gx, y: gy)] = cell
             }
         }
     }
@@ -241,7 +241,8 @@ final class BoardViewModel: ObservableObject {
     private func updateCell(at pos: (Int, Int), with card: Card, isCard _: Bool) {
         let cell = BoardCell(type: card.type, contributor: currentPlayer.value)
 
-        placedCards.value["\(pos.0),\(pos.1)"] = cell
+        placedCards.value[Coordinate(x: pos.0, y: pos.1)] = cell
+        print("\(placedCards.value)")
         board.grid[pos.0][pos.1] = cell
 
         latestPlacedCoord.value = Coordinate(x: pos.0, y: pos.1)
@@ -393,10 +394,8 @@ final class BoardViewModel: ObservableObject {
 
     /// P2P 동기화된 카드 배치를 로컬 보드에 반영
     func syncBoardWithPlacedCards() {
-        for (key, cell) in placedCards.value {
-            let coords = key.split(separator: ",").compactMap { Int($0) }
-            guard coords.count == 2 else { continue }
-            board.grid[coords[0]][coords[1]] = cell
+        for (coord, cell) in placedCards.value {
+            board.grid[coord.x][coord.y] = cell
         }
     }
 

--- a/Saboteur/Features/GamePlay/Models/Coordinate.swift
+++ b/Saboteur/Features/GamePlay/Models/Coordinate.swift
@@ -5,7 +5,7 @@
 //  Created by kirby on 7/26/25.
 //
 
-struct Coordinate: Codable, Equatable {
+struct Coordinate: Codable, Equatable, Hashable {
     let x: Int
     let y: Int
 }


### PR DESCRIPTION
커비와 페어 코딩

테스트 케이스 41: 플레이어간 턴 전환 타이머 및 board status 반영 실패를 해결하기 위함